### PR TITLE
Header label

### DIFF
--- a/app/labels/header.rb
+++ b/app/labels/header.rb
@@ -1,0 +1,12 @@
+class Header < Engine::Label
+  def initialize(args = {})
+    @x = args.fetch(:x, Viewport.xcenter(0))
+    @y = args.fetch(:y, Viewport.vcenter(-400))
+    @text = args.fetch(:text)
+    @size = args.fetch(:size, 48)
+    @alignment = args.fetch(:alignment, 1)
+    @color = args.fetch(:color, ColorPalette.pink)
+    @alpha = args.fetch(:alpha, 255)
+    @font = args.fetch(:font, "app/assets/fonts/RocketRinder.ttf")
+  end
+end

--- a/lib/engine/label.rb
+++ b/lib/engine/label.rb
@@ -1,0 +1,9 @@
+module Engine
+  class Label
+    attr_accessor :x, :y, :text, :size, :alignment, :color, :alpha, :font
+
+    def render
+      $args.outputs.labels << [x, y, text, size, alignment, *color, alpha, font].compact
+    end
+  end
+end


### PR DESCRIPTION
### Label

Base label. Self-aware for easier rendering. No defaults to keep it abstracted.

### Header

Set to replace `GameTitleLayer`. Idea is to have concepts we can create many of. I needed another "GameTitleLayer" for the death screen. Except I didn't want it to say "Breakout", but more like "You died bitch!". Working with concepts like this should make it easier to spin up new instances.