### PR TITLE
Adds on_keys on Engine::Input

### DIFF
--- a/lib/engine/input.rb
+++ b/lib/engine/input.rb
@@ -5,5 +5,11 @@ module Engine
 
       yield if block_given?
     end
+
+    def on_keys(*keys, &block)
+      keys.each do |key|
+        on_key(key, &block)
+      end
+    end
   end
 end


### PR DESCRIPTION
Will be useful for settings later on

```ruby
on_keys(:left, :right) { toggle! }
```