### PR TITLE
Adds Container & Edge with collisions

### DIFF
--- a/app/labels/header.rb
+++ b/app/labels/header.rb
@@ -1,7 +1,7 @@
 class Header < Engine::Label
   def initialize(args = {})
-    @x = args.fetch(:x, Viewport.xcenter(0))
-    @y = args.fetch(:y, Viewport.vcenter(-400))
+    @x = args.fetch(:x, Viewport.xcenter)
+    @y = args.fetch(:y, (Viewport.ycenter + 200))
     @text = args.fetch(:text)
     @size = args.fetch(:size, 48)
     @alignment = args.fetch(:alignment, 1)

--- a/app/labels/menu_item.rb
+++ b/app/labels/menu_item.rb
@@ -4,8 +4,8 @@ class MenuItem < Engine::Label
   alias :selected? :selected
 
   def initialize(args = {}, &block)
-    @x = args.fetch(:x, Viewport.xcenter(0))
-    @y = args.fetch(:y, Viewport.ycenter(-400))
+    @x = args.fetch(:x, Viewport.xcenter)
+    @y = args.fetch(:y, (Viewport.ycenter + 200))
     @text = args.fetch(:text)
     @size = args.fetch(:size, 18)
     @alignment = args.fetch(:alignment, 1)

--- a/app/models/ball.rb
+++ b/app/models/ball.rb
@@ -4,7 +4,7 @@ class Ball < Engine::Model
   POSITION_Y = 25
 
   def initialize
-    @x = Viewport.xcenter(DEFAULT_SIZE)
+    @x = Viewport.xcenter
     @y = POSITION_Y
     @width = DEFAULT_SIZE
     @height = DEFAULT_SIZE
@@ -31,8 +31,6 @@ class Ball < Engine::Model
     self.clone.travel!
   end
 
-  private
-
   def bounce_horizontally
     @horizontal_speed = -@horizontal_speed
   end
@@ -40,6 +38,8 @@ class Ball < Engine::Model
   def bounce_vertically
     @vertical_speed = -@vertical_speed
   end
+
+  private
 
   def travel!
     travel_horizontally!

--- a/app/models/brick_layout.rb
+++ b/app/models/brick_layout.rb
@@ -37,7 +37,7 @@ class BrickLayout < Engine::Model
   end
 
   def left_edge
-    @left_edge ||= Viewport.xcenter(columns * Brick::WIDTH)
+    @left_edge ||= Viewport.xcenter - (columns * Brick::WIDTH / 2)
   end
 
   def top_edge

--- a/app/models/menu.rb
+++ b/app/models/menu.rb
@@ -3,7 +3,7 @@ class Menu
 
   attr_accessor :options, :margin, :offset
 
-  def initialize(margin: 150, offset: 0)
+  def initialize(margin: 75, offset: 0)
     @options = []
     @margin = margin
     @offset = offset
@@ -20,7 +20,7 @@ class Menu
   end
 
   def add_option(label, &block)
-    y = Viewport.vcenter(offset + options.length * margin)
+    y = Viewport.ycenter - offset - options.length * margin
     selected = (options.length == 0)
     option = MenuItem.new(text: label, y: y, selected: selected, on_select: block)
     options << option

--- a/app/models/paddle.rb
+++ b/app/models/paddle.rb
@@ -7,7 +7,7 @@ class Paddle < Engine::Model
   POSITION_Y = 15
 
   def initialize
-    @x = Viewport.xcenter + DEFAULT_WIDTH
+    @x = Viewport.xcenter - (DEFAULT_WIDTH / 2)
     @y = POSITION_Y
     @width = DEFAULT_WIDTH
     @height = DEFAULT_HEIGHT

--- a/app/models/paddle.rb
+++ b/app/models/paddle.rb
@@ -7,7 +7,7 @@ class Paddle < Engine::Model
   POSITION_Y = 15
 
   def initialize
-    @x = Viewport.xcenter(DEFAULT_WIDTH)
+    @x = Viewport.xcenter + DEFAULT_WIDTH
     @y = POSITION_Y
     @width = DEFAULT_WIDTH
     @height = DEFAULT_HEIGHT

--- a/app/screens/level_screen.rb
+++ b/app/screens/level_screen.rb
@@ -23,11 +23,11 @@ class LevelScreen < Engine::Screen
       ball.bounce_off(brick)
     end
 
-    on_collision(ball.next_ball, [Viewport.left, Viewport.right]) do |edge|
+    on_collision(ball.next_ball, [Viewport.left, Viewport.right]) do
       ball.bounce_horizontally
     end
 
-    on_collision(ball.next_ball, [Viewport.top]) do |edge|
+    on_collision(ball.next_ball, [Viewport.top]) do
       ball.bounce_vertically
     end
 

--- a/app/screens/level_screen.rb
+++ b/app/screens/level_screen.rb
@@ -31,7 +31,7 @@ class LevelScreen < Engine::Screen
       ball.bounce_vertically
     end
 
-    on_collision(ball.next_ball, [Viewport.bottom]) do
+    on_collision(ball, [Viewport.bottom]) do
       $args.state.screen = :death
     end
   end

--- a/app/screens/level_screen.rb
+++ b/app/screens/level_screen.rb
@@ -24,14 +24,14 @@ class LevelScreen < Engine::Screen
     end
 
     on_collision(ball.next_ball, [Viewport.left, Viewport.right]) do |edge|
-      ball.bounce_off(edge)
+      ball.bounce_horizontally
     end
 
     on_collision(ball.next_ball, [Viewport.top]) do |edge|
-      ball.bounce_off(edge)
+      ball.bounce_vertically
     end
 
-    on_collision(ball, [Viewport.bottom]) do
+    on_collision(ball.next_ball, [Viewport.bottom]) do
       $args.state.screen = :death
     end
   end

--- a/lib/autoload.rb
+++ b/lib/autoload.rb
@@ -12,6 +12,7 @@ require "lib/engine/viewport.rb"
 
 # Depends on Model
 require "lib/engine/container.rb"
+require "lib/engine/edge.rb"
 
 require "app/assets/color_palette.rb"
 require "app/controllers/game_controller.rb"

--- a/lib/autoload.rb
+++ b/lib/autoload.rb
@@ -10,6 +10,9 @@ require "lib/engine/screen.rb"
 require "lib/engine/settings.rb"
 require "lib/engine/viewport.rb"
 
+# Depends on Model
+require "lib/engine/container.rb"
+
 require "app/assets/color_palette.rb"
 require "app/controllers/game_controller.rb"
 require "app/effects/ossilator.rb"

--- a/lib/autoload.rb
+++ b/lib/autoload.rb
@@ -1,19 +1,24 @@
 require "lib/core_ext/keyboard.rb"
 require "lib/core_ext/string.rb"
+
+# Extensions
 require "lib/engine/action.rb"
-require "lib/engine/collision.rb"
 require "lib/engine/input.rb"
+require "lib/engine/collision.rb"
+
+# Core Objects
 require "lib/engine/label.rb"
 require "lib/engine/line.rb"
 require "lib/engine/model.rb"
 require "lib/engine/screen.rb"
+
+# Helpers
+require "lib/engine/container.rb"
+require "lib/engine/edge.rb"
 require "lib/engine/settings.rb"
 require "lib/engine/viewport.rb"
 
-# Depends on Model
-require "lib/engine/container.rb"
-require "lib/engine/edge.rb"
-
+# Application
 require "app/assets/color_palette.rb"
 require "app/controllers/game_controller.rb"
 require "app/effects/ossilator.rb"

--- a/lib/engine/collision.rb
+++ b/lib/engine/collision.rb
@@ -2,9 +2,38 @@ module Engine
   module Collision
     def on_collision(source, destinations, &block)
       destinations.each do |destination|
-        next unless GTK::Geometry.intersect_rect?(source.rect, destination.rect)
+        on_edge_collision(source, destination, &block) if destination.is_a?(Edge)
+        on_solid_collision(source, destination, &block) if destination.is_a?(Model)
+      end
+    end
 
-        yield(destination)
+    def on_edge_collision(source, edge, &block)
+      return unless outside?(source, edge)
+
+      yield(edge)
+    end
+
+    def on_solid_collision(source, destination, &block)
+      return unless collides?(source, destination)
+
+      yield(destination)
+    end
+
+    def collides?(source, destination)
+      GTK::Geometry.intersect_rect?(source.rect, destination.rect)
+    end
+
+    def outside?(source, edge)
+      if edge.is_a? Engine::Edge::Left
+        source.x < edge.x
+      elsif edge.is_a? Engine::Edge::Right
+        (source.x + source.width) > edge.x
+      elsif edge.is_a? Engine::Edge::Top
+        (source.y + source.height) > edge.y
+      elsif edge.is_a? Engine::Edge::Bottom
+        source.y < edge.y
+      else
+        false
       end
     end
   end

--- a/lib/engine/collision.rb
+++ b/lib/engine/collision.rb
@@ -8,7 +8,7 @@ module Engine
     end
 
     def on_edge_collision(source, edge, &block)
-      return unless outside?(source, edge)
+      return if edge.contains?(source)
 
       yield(edge)
     end
@@ -21,20 +21,6 @@ module Engine
 
     def collides?(source, destination)
       GTK::Geometry.intersect_rect?(source.rect, destination.rect)
-    end
-
-    def outside?(source, edge)
-      if edge.is_a? Engine::Edge::Left
-        source.x < edge.x
-      elsif edge.is_a? Engine::Edge::Right
-        (source.x + source.width) > edge.x
-      elsif edge.is_a? Engine::Edge::Top
-        (source.y + source.height) > edge.y
-      elsif edge.is_a? Engine::Edge::Bottom
-        source.y < edge.y
-      else
-        false
-      end
     end
   end
 end

--- a/lib/engine/collision.rb
+++ b/lib/engine/collision.rb
@@ -8,19 +8,15 @@ module Engine
     end
 
     def on_edge_collision(source, edge, &block)
-      return if edge.contains?(source)
+      return unless source.beyond?(edge)
 
       yield(edge)
     end
 
-    def on_solid_collision(source, destination, &block)
-      return unless collides?(source, destination)
+    def on_solid_collision(source, solid, &block)
+      return unless source.collides?(solid)
 
-      yield(destination)
-    end
-
-    def collides?(source, destination)
-      GTK::Geometry.intersect_rect?(source.rect, destination.rect)
+      yield(solid)
     end
   end
 end

--- a/lib/engine/container.rb
+++ b/lib/engine/container.rb
@@ -1,0 +1,34 @@
+module Engine
+  class Container < Model
+    def contains?(solid)
+      left.contains?(solid) &&
+      right.contains?(solid) &&
+      top.contains?(solid) &&
+      bottom.contains?(solid)
+    end
+
+    def xcenter
+      x + width / 2
+    end
+
+    def ycenter
+      y + height / 2
+    end
+
+    def left
+      @left ||= Edge::Left.new(x: x, y: y, x2: x, y2: (y + height))
+    end
+
+    def right
+      @right ||= Edge::Right.new(x: (x + width), y: y, x2: (x + width), y2: (y + height))
+    end
+
+    def bottom
+      @bottom ||= Edge::Bottom.new(x: x, y: y, x2: (x + width), y2: y)
+    end
+
+    def top
+      @top ||= Edge::Top.new(x: x, y: (y + height), x2: (x + width), y2: (y + height))
+    end
+  end
+end

--- a/lib/engine/edge.rb
+++ b/lib/engine/edge.rb
@@ -1,0 +1,27 @@
+module Engine
+  class Edge < Line
+    class Left < Edge
+      def contains?(solid)
+        solid.left < x
+      end
+    end
+
+    class Right < Edge
+      def contains?(solid)
+        solid.right > x
+      end
+    end
+
+    class Top < Edge
+      def contains?(solid)
+        solid.top > y
+      end
+    end
+
+    class Bottom < Edge
+      def contains?(solid)
+        solid.bottom < y
+      end
+    end
+  end
+end

--- a/lib/engine/edge.rb
+++ b/lib/engine/edge.rb
@@ -2,25 +2,25 @@ module Engine
   class Edge < Line
     class Left < Edge
       def contains?(solid)
-        solid.left < x
+        solid.left >= x
       end
     end
 
     class Right < Edge
       def contains?(solid)
-        solid.right > x
+        solid.right <= x
       end
     end
 
     class Top < Edge
       def contains?(solid)
-        solid.top > y
+        solid.top <= y
       end
     end
 
     class Bottom < Edge
       def contains?(solid)
-        solid.bottom < y
+        solid.bottom >= y
       end
     end
   end

--- a/lib/engine/model.rb
+++ b/lib/engine/model.rb
@@ -44,5 +44,9 @@ module Engine
     def beyond?(edge)
       !edge.contains?(self)
     end
+
+    def collides?(destination)
+      GTK::Geometry.intersect_rect?(rect, destination.rect)
+    end
   end
 end

--- a/lib/engine/model.rb
+++ b/lib/engine/model.rb
@@ -20,5 +20,29 @@ module Engine
     def rect
       [x, y, width, height]
     end
+
+    def left
+      x
+    end
+
+    def right
+      x + width
+    end
+
+    def top
+      y + height
+    end
+
+    def bottom
+      y
+    end
+
+    def outside?(container)
+      !container.contains?(self)
+    end
+
+    def beyond?(edge)
+      !edge.contains?(self)
+    end
   end
 end

--- a/lib/engine/viewport.rb
+++ b/lib/engine/viewport.rb
@@ -1,11 +1,15 @@
-class Viewport
+class Viewport < Engine::Container
+  def initialize
+    super(x: 0, y: 0, width: 1280, height: 720)
+  end
+
   class << self
-    def _container
-      @_container ||= Engine::Container.new(x: 0, y: 0, width: 1280, height: 720)
+    def instance
+      @instance ||= new
     end
 
     def method_missing(method)
-      _container.send(method)
+      instance.send(method)
     end
   end
 end

--- a/lib/engine/viewport.rb
+++ b/lib/engine/viewport.rb
@@ -1,40 +1,11 @@
 class Viewport
-  WIDTH = 1280
-  HEIGHT = 720
-
   class << self
-    def xcenter(offset)
-      (width - offset) / 2
-    end
-    alias :hcenter :xcenter
-
-    def ycenter(offset)
-      (height - offset) / 2
-    end
-    alias :vcenter :ycenter
-
-    def width
-      WIDTH
+    def _container
+      @_container ||= Engine::Container.new(x: 0, y: 0, width: 1280, height: 720)
     end
 
-    def height
-      HEIGHT
-    end
-
-    def left
-      @left ||= Engine::Model.new(x: 0, y: 0, width: 0, height: height)
-    end
-
-    def right
-      @right ||= Engine::Model.new(x: width, y: 0, width: 0, height: height)
-    end
-
-    def bottom
-      @bottom ||= Engine::Model.new(x: 0, y: 0, width: width, height: 0)
-    end
-
-    def top
-      @top ||= Engine::Model.new(x: 0, y: height, width: width, height: 0)
+    def method_missing(method)
+      _container.send(method)
     end
   end
 end


### PR DESCRIPTION
`Engine::Container` will be useful to split the screen in multiple "sectors" and use it to infer `x` and `y` values from its origins.
`Engine::Edge` and its subclasses will help create bounding boxes around our containers. They are now integrated as `Engine::Line` which is more appropriate than a zero-width solid lol
I had to refactor our collision engine to look for _greater than_ values rather than intersections on edges. A ball flying at too high a speed would go through and never actually intersect if it flies faster than 2 pixels per tick.

- Removes `offset` from `#xcenter` & `#ycenter`. It wasn't doing the right thing anyway.
- Implements `Viewport` as a `Engine::Container`
- Adds `contains?` and `beyond?` helper methods